### PR TITLE
Families

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,11 @@
 class ApplicationController < ActionController::Base
+
+  private
+
+  def current_user
+    token = request.headers["Authorization"].to_s
+    email = Base64.decode64(token)
+
+    User.find_by(email: email)
+  end
 end

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -6,7 +6,7 @@ class GraphqlController < ApplicationController
     operation_name = params[:operationName]
     context = {
       # Query context goes here, for example:
-      # current_user: current_user,
+      current_user: current_user,
     }
     result = CoderdojoBeSchema.execute(query, variables: variables, context: context, operation_name: operation_name)
     render json: result
@@ -41,4 +41,5 @@ class GraphqlController < ApplicationController
 
     render json: { error: { message: e.message, backtrace: e.backtrace }, data: {} }, status: 500
   end
+
 end

--- a/app/graphql/mutations/create_student.rb
+++ b/app/graphql/mutations/create_student.rb
@@ -1,0 +1,29 @@
+module Mutations
+  class CreateStudent < Mutations::BaseMutation
+    argument :nickname, String, required: true
+    argument :password, String, required: true
+    argument :role, Integer, required: true
+    argument :name, String, required: false
+    # return type from the mutation
+    type Types::UserType
+
+    def resolve(nickname: nil,
+            password: nil,
+                role: nil,
+                name: nil,
+         guardian_id: nil)
+
+      if context[:current_user].nil?
+        raise GraphQL::ExecutionError,
+        "You need to authenticate to perform this action"
+      end
+
+      User.create!(
+        nickname: nickname,
+        password: password,
+            role: role,
+            name: name,
+     guardian_id: context[:current_user][:id])
+   end
+  end
+end

--- a/app/graphql/mutations/create_user.rb
+++ b/app/graphql/mutations/create_user.rb
@@ -3,27 +3,24 @@ module Mutations
     argument :email, String, required: false
     argument :nickname, String, required: true
     argument :password, String, required: true
-    argument :role, Integer, required: true
     argument :name, String, required: false
     argument :phone_number, String, required: false
     # return type from the mutation
-   type Types::UserType
+    type Types::UserType
 
-   def resolve(email: nil,
+    def resolve(email: nil,
             nickname: nil,
             password: nil,
-                role: nil,
                 name: nil,
         phone_number: nil)
-
-     User.create!(
-          email: email,
-       nickname: nickname,
-       password: password,
-           role: role,
-           name: name,
-   phone_number: phone_number,
-     )
-   end
+      
+      User.create!(
+           email: email,
+        nickname: nickname,
+        password: password,
+            role: 1,
+            name: name,
+    phone_number: phone_number)
+    end
   end
 end

--- a/app/graphql/mutations/create_user.rb
+++ b/app/graphql/mutations/create_user.rb
@@ -1,12 +1,11 @@
 module Mutations
-  class CreateUser < BaseMutation
+  class CreateUser < Mutations::BaseMutation
     argument :email, String, required: false
     argument :nickname, String, required: true
     argument :password, String, required: true
     argument :role, Integer, required: true
     argument :name, String, required: false
     argument :phone_number, String, required: false
-    argument :guardian_id, Integer, required: false
     # return type from the mutation
    type Types::UserType
 
@@ -15,8 +14,7 @@ module Mutations
             password: nil,
                 role: nil,
                 name: nil,
-        phone_number: nil,
-         guardian_id: nil)
+        phone_number: nil)
 
      User.create!(
           email: email,
@@ -25,7 +23,6 @@ module Mutations
            role: role,
            name: name,
    phone_number: phone_number,
-    guardian_id: guardian_id
      )
    end
   end

--- a/app/graphql/mutations/sign_in.rb
+++ b/app/graphql/mutations/sign_in.rb
@@ -1,0 +1,21 @@
+module Mutations
+  class SignIn < Mutations::BaseMutation
+    argument :email, String, required: true
+    argument :password, String, required: true
+
+    field :token, String, null: true
+    field :user, Types::UserType, null: true
+
+    def resolve(email: nil, password: nil)
+      user = User.find_by!(email: email)
+      return {} unless user
+      return {} unless user.password == password
+
+      token = Base64.encode64(user.email)
+      {
+        token: token,
+        user: user
+      }
+    end
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -2,5 +2,7 @@ module Types
   class MutationType < Types::BaseObject
 
     field :create_user, mutation: Mutations::CreateUser
+    field :sign_in, mutation: Mutations::SignIn
+    field :create_student, mutation: Mutations::CreateStudent
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -3,7 +3,11 @@ module Types
     # Add root-level fields here.
     # They will be entry points for queries on your schema.
     field :all_users, [UserType], null: false
+    field :me, Types::UserType, null: true
 
+    def me
+      context[:current_user]
+    end
 
     def all_users
       User.all

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -4,7 +4,7 @@ module Types
     field :email, String, null: true
     field :nickname, String, null: false
     field :password, String, null: false
-    field :role, Integer, null: false
+    field :role, Integer, null: true
     field :name, String, null: true
     field :notes, String, null: true
     field :phone_number, String, null: true

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -8,7 +8,8 @@ module Types
     field :name, String, null: true
     field :notes, String, null: true
     field :phone_number, String, null: true
-    field :guardian_id, Integer, null: true
+    field :guardian_id, UserType, null: true, method: :guardian
+    field :students, [UserType], null: true, method: :students
     field :created_at, String, null: false
     field :updated_at, String, null: false
   end

--- a/spec/mutations/create_user_spec.rb
+++ b/spec/mutations/create_user_spec.rb
@@ -9,14 +9,12 @@ class Mutations::CreateUserTest < ActiveSupport::TestCase
     it 'create a new user' do
       user = perform(
         nickname: 'Duce',
-        role: 0,
         password: 'password'
       )
 
       assert user.persisted?
       assert_equal user.nickname, 'Duce'
       assert_equal user.password, 'password'
-      assert_equal user.role, 0
     end
   end
 end


### PR DESCRIPTION
This PR adds mutations for a better flow when creating and authenticating users.

A registering user will now automatically be assigned role:1. 

This user can then sign in with email and password. this returns a token (lightly encrypted email)

This token will be passed in the headers with the key "Authorization" for mutations that require a user to be signed in.

CreateStudent allows a user to be created with only name, nickname, and password. A guardian user must be logged in and pass in an auth token as mentioned above. This will create a student with role:0 and establish the current_user id as a foreign key for guardian_id