### PR TITLE
Create user with address

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,8 +4,8 @@ class ApplicationController < ActionController::Base
 
   def current_user
     token = request.headers["Authorization"].to_s
-    email = Base64.decode64(token)
+    username = Base64.decode64(token)
 
-    User.find_by(email: email)
+    User.find_by(username: username)
   end
 end

--- a/app/graphql/mutations/create_student.rb
+++ b/app/graphql/mutations/create_student.rb
@@ -2,25 +2,22 @@ module Mutations
   class CreateStudent < Mutations::BaseMutation
     argument :username, String, required: true
     argument :password, String, required: true
-    argument :name, String, required: false
+    argument :name, String, required: true
+    argument :birthdate, String, required: true
     # return type from the mutation
     type Types::UserType
 
-    def resolve(nickname: nil,
+    def resolve(username: nil,
             password: nil,
                 name: nil,
          birthdate: nil)
 
-      if context[:current_user].nil?
-        raise GraphQL::ExecutionError,
-        "You need to authenticate to perform this action"
-      end
-
       User.create!(
-        nickname: nickname,
+        username: nickname,
         password: password,
-            role: role,
+            role: 0,
             name: name,
+       birthdate: birthdate,
      guardian_id: context[:current_user][:id])
    end
   end

--- a/app/graphql/mutations/create_student.rb
+++ b/app/graphql/mutations/create_student.rb
@@ -13,7 +13,7 @@ module Mutations
          birthdate: nil)
 
       User.create!(
-        username: nickname,
+        username: username,
         password: password,
             role: 0,
             name: name,

--- a/app/graphql/mutations/create_student.rb
+++ b/app/graphql/mutations/create_student.rb
@@ -1,17 +1,15 @@
 module Mutations
   class CreateStudent < Mutations::BaseMutation
-    argument :nickname, String, required: true
+    argument :username, String, required: true
     argument :password, String, required: true
-    argument :role, Integer, required: true
     argument :name, String, required: false
     # return type from the mutation
     type Types::UserType
 
     def resolve(nickname: nil,
             password: nil,
-                role: nil,
                 name: nil,
-         guardian_id: nil)
+         birthdate: nil)
 
       if context[:current_user].nil?
         raise GraphQL::ExecutionError,

--- a/app/graphql/mutations/create_student.rb
+++ b/app/graphql/mutations/create_student.rb
@@ -12,6 +12,7 @@ module Mutations
                 name: nil,
          birthdate: nil)
 
+
       User.create!(
         username: username,
         password: password,

--- a/app/graphql/mutations/create_user.rb
+++ b/app/graphql/mutations/create_user.rb
@@ -21,8 +21,8 @@ module Mutations
              password: nil,
                  name: nil,
          phone_number: nil,
-             street_1: nil,
-             street_2: nil,
+             street1: nil,
+             street2: nil,
                  city: nil,
                 state: nil,
                   zip: nil)
@@ -36,12 +36,12 @@ module Mutations
         phone_number: phone_number)
 
       address = user.addresses.create!(
-        street_1: street_1,
-        street_2: street_2,
+        street_1: street1,
+        street_2: street2,
             city: city,
            state: state,
              zip: zip)
-             
+
       return user
     end
   end

--- a/app/graphql/mutations/create_user.rb
+++ b/app/graphql/mutations/create_user.rb
@@ -16,7 +16,7 @@ module Mutations
 
       User.create!(
            email: email,
-        nickname: nickname,
+        username: username,
         password: password,
             role: 1,
             name: name,

--- a/app/graphql/mutations/create_user.rb
+++ b/app/graphql/mutations/create_user.rb
@@ -27,21 +27,22 @@ module Mutations
                 state: nil,
                   zip: nil)
 
-      address = Address.create!(
+      user = User.create!(
+        email: email,
+        username: username,
+        password: password,
+        role: 1,
+        name: name,
+        phone_number: phone_number)
+
+      address = user.addresses.create!(
         street_1: street_1,
         street_2: street_2,
             city: city,
            state: state,
              zip: zip)
-
-      User.create!(
-           email: email,
-        username: username,
-        password: password,
-            role: 1,
-            name: name,
-    phone_number: phone_number,
-      address_id: address.id)
+             
+      return user
     end
   end
 end

--- a/app/graphql/mutations/create_user.rb
+++ b/app/graphql/mutations/create_user.rb
@@ -1,19 +1,19 @@
 module Mutations
   class CreateUser < Mutations::BaseMutation
-    argument :email, String, required: false
-    argument :nickname, String, required: true
+    argument :email, String, required: true
+    argument :username, String, required: true
     argument :password, String, required: true
-    argument :name, String, required: false
-    argument :phone_number, String, required: false
+    argument :name, String, required: true
+    argument :phone_number, String, required: true
     # return type from the mutation
     type Types::UserType
 
     def resolve(email: nil,
-            nickname: nil,
+            username: nil,
             password: nil,
                 name: nil,
         phone_number: nil)
-      
+
       User.create!(
            email: email,
         nickname: nickname,

--- a/app/graphql/mutations/create_user.rb
+++ b/app/graphql/mutations/create_user.rb
@@ -1,18 +1,38 @@
 module Mutations
   class CreateUser < Mutations::BaseMutation
+    #User args
     argument :email, String, required: true
     argument :username, String, required: true
     argument :password, String, required: true
     argument :name, String, required: true
     argument :phone_number, String, required: true
+    #Address args
+    argument :street_1, String, required: true
+    argument :street_2, String, required: false
+    argument :city, String, required: true
+    argument :state, String, required: true
+    argument :zip, String, required: true
+
     # return type from the mutation
     type Types::UserType
 
     def resolve(email: nil,
-            username: nil,
-            password: nil,
-                name: nil,
-        phone_number: nil)
+             username: nil,
+             password: nil,
+                 name: nil,
+         phone_number: nil,
+             street_1: nil,
+             street_2: nil,
+                 city: nil,
+                state: nil,
+                  zip: nil)
+
+      address = Address.create!(
+        street_1: street_1,
+        street_2: street_2,
+            city: city,
+           state: state,
+             zip: zip)
 
       User.create!(
            email: email,
@@ -20,7 +40,8 @@ module Mutations
         password: password,
             role: 1,
             name: name,
-    phone_number: phone_number)
+    phone_number: phone_number,
+      address_id: address.id)
     end
   end
 end

--- a/app/graphql/mutations/sign_in.rb
+++ b/app/graphql/mutations/sign_in.rb
@@ -1,17 +1,17 @@
 module Mutations
   class SignIn < Mutations::BaseMutation
-    argument :email, String, required: true
+    argument :username, String, required: true
     argument :password, String, required: true
 
     field :token, String, null: true
     field :user, Types::UserType, null: true
 
-    def resolve(email: nil, password: nil)
-      user = User.find_by!(email: email)
+    def resolve(username: nil, password: nil)
+      user = User.find_by!(username: username)
       return {} unless user
       return {} unless user.password == password
 
-      token = Base64.encode64(user.email)
+      token = Base64.encode64(user.username)
       {
         token: token,
         user: user

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -4,5 +4,5 @@ class Address < ApplicationRecord
   validates_presence_of :state
   validates_presence_of :zip
 
-  belongs_to :user
+  belongs_to :addressable, polymorphic: true, optional: true
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,0 +1,6 @@
+class Address < ApplicationRecord
+  validates_presence_of :street_1
+  validates_presence_of :city
+  validates_presence_of :state
+  validates_presence_of :zip
+end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -3,4 +3,6 @@ class Address < ApplicationRecord
   validates_presence_of :city
   validates_presence_of :state
   validates_presence_of :zip
+
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,6 @@
 class User < ApplicationRecord
-  validates_presence_of :nickname
+  validates_presence_of :username
   validates_presence_of :password
-  validates_presence_of :role
 
   has_many :students, class_name: "User",
                      foreign_key: "guardian_id"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   validates_presence_of :username
   validates_presence_of :password
+  validates_uniqueness_of :username
 
   has_many :students, class_name: "User",
                      foreign_key: "guardian_id"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,5 +8,5 @@ class User < ApplicationRecord
 
   belongs_to :guardian, optional: true, class_name: "User"
 
-  has_one :address
+  has_many :addresses, :as => :addressable
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,6 @@ class User < ApplicationRecord
                      foreign_key: "guardian_id"
 
   belongs_to :guardian, optional: true, class_name: "User"
+
+  has_one :address
 end

--- a/db/migrate/20190716171629_change_users_table.rb
+++ b/db/migrate/20190716171629_change_users_table.rb
@@ -1,0 +1,6 @@
+class ChangeUsersTable < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :users, :nickname, :username
+    add_column :users, :birthdate, :string
+  end
+end

--- a/db/migrate/20190716172813_create_addresses.rb
+++ b/db/migrate/20190716172813_create_addresses.rb
@@ -1,0 +1,13 @@
+class CreateAddresses < ActiveRecord::Migration[5.2]
+  def change
+    create_table :addresses do |t|
+      t.string :street_1
+      t.string :street_2
+      t.string :city
+      t.string :state
+      t.string :zip
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190716174815_add_adress_column_to_users.rb
+++ b/db/migrate/20190716174815_add_adress_column_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdressColumnToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :address_id, :integer
+  end
+end

--- a/db/migrate/20190716214438_address_relationships.rb
+++ b/db/migrate/20190716214438_address_relationships.rb
@@ -1,0 +1,6 @@
+class AddressRelationships < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :users, :address_id
+    add_reference :addresses, :addressable, polymorphic: true, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_16_171629) do
+ActiveRecord::Schema.define(version: 2019_07_16_172813) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "addresses", force: :cascade do |t|
+    t.string "street_1"
+    t.string "street_2"
+    t.string "city"
+    t.string "state"
+    t.string "zip"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_16_174815) do
+ActiveRecord::Schema.define(version: 2019_07_16_214438) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,9 @@ ActiveRecord::Schema.define(version: 2019_07_16_174815) do
     t.string "zip"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "addressable_type"
+    t.bigint "addressable_id"
+    t.index ["addressable_type", "addressable_id"], name: "index_addresses_on_addressable_type_and_addressable_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -37,7 +40,6 @@ ActiveRecord::Schema.define(version: 2019_07_16_174815) do
     t.datetime "updated_at", null: false
     t.bigint "guardian_id"
     t.string "birthdate"
-    t.integer "address_id"
     t.index ["guardian_id"], name: "index_users_on_guardian_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_15_220612) do
+ActiveRecord::Schema.define(version: 2019_07_16_171629) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "users", force: :cascade do |t|
     t.string "email"
-    t.string "nickname"
+    t.string "username"
     t.string "password"
     t.integer "role"
     t.string "name"
@@ -26,6 +26,7 @@ ActiveRecord::Schema.define(version: 2019_07_15_220612) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "guardian_id"
+    t.string "birthdate"
     t.index ["guardian_id"], name: "index_users_on_guardian_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_16_172813) do
+ActiveRecord::Schema.define(version: 2019_07_16_174815) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,6 +37,7 @@ ActiveRecord::Schema.define(version: 2019_07_16_172813) do
     t.datetime "updated_at", null: false
     t.bigint "guardian_id"
     t.string "birthdate"
+    t.integer "address_id"
     t.index ["guardian_id"], name: "index_users_on_guardian_id"
   end
 

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe Address, type: :model do
+  describe "validations" do
+    it{should validate_presence_of(:street_1)}
+    it{should validate_presence_of(:city)}
+    it{should validate_presence_of(:state)}
+    it{should validate_presence_of(:zip)}
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,8 +2,7 @@ require 'rails_helper'
 
 describe User, type: :model do
   describe 'validations' do
-    it{should validate_presence_of(:nickname)}
+    it{should validate_presence_of(:username)}
     it{should validate_presence_of(:password)}
-    it{should validate_presence_of(:role)}
   end
 end

--- a/spec/mutations/create_user_spec.rb
+++ b/spec/mutations/create_user_spec.rb
@@ -11,7 +11,7 @@ class Mutations::CreateUserTest < ActiveSupport::TestCase
         name: 'Matt W',
         username: 'Duce',
         password: 'password',
-        street_1: '123 main',
+        street1: '123 main',
         city: 'Denver',
         state: 'CO',
         zip: '80128'

--- a/spec/mutations/create_user_spec.rb
+++ b/spec/mutations/create_user_spec.rb
@@ -8,13 +8,19 @@ class Mutations::CreateUserTest < ActiveSupport::TestCase
 
     it 'create a new user' do
       user = perform(
+        name: 'Matt W',
         username: 'Duce',
-        password: 'password'
+        password: 'password',
+        street_1: '123 main',
+        city: 'Denver',
+        state: 'CO',
+        zip: '80128'
       )
 
       assert user.persisted?
       assert_equal user.username, 'Duce'
       assert_equal user.password, 'password'
+      assert_equal user.addresses[0].city, 'Denver'
     end
   end
 end

--- a/spec/mutations/create_user_spec.rb
+++ b/spec/mutations/create_user_spec.rb
@@ -8,12 +8,12 @@ class Mutations::CreateUserTest < ActiveSupport::TestCase
 
     it 'create a new user' do
       user = perform(
-        nickname: 'Duce',
+        username: 'Duce',
         password: 'password'
       )
 
       assert user.persisted?
-      assert_equal user.nickname, 'Duce'
+      assert_equal user.username, 'Duce'
       assert_equal user.password, 'password'
     end
   end


### PR DESCRIPTION
This PR makes a host of changes to the existing mutations to enable the addition of addresses, and tweaks the schema to conform to the desired UX.

createUser mutation now requires address info for user creation, and also creates an address linked to that user.

createStudent mutation now creates a student/guardian relationship if the guardian is signed in. For students over 13 registering themselves, guardian_id remains null.

signIn mutation allows a user (student or guardian) to sign in using their username and password. A token is returned that is currently a basic encryption of their username. We will upgrade this to JWT later. This token can be passed back with requests in the headers with the "Authorization" key for requests requiring us to know who the current user is.