### PR TITLE
Sanitizes city input to be stored downcased.

### DIFF
--- a/app/graphql/mutations/create_event.rb
+++ b/app/graphql/mutations/create_event.rb
@@ -39,7 +39,7 @@ module Mutations
           event.addresses.create(
             street_1: street1,
             street_2: street2,
-                city: city,
+                city: city.downcase,
                state: state,
                  zip: zip)
         end

--- a/app/graphql/mutations/create_user.rb
+++ b/app/graphql/mutations/create_user.rb
@@ -43,7 +43,7 @@ module Mutations
         address = user.addresses.create!(
           street_1: street1,
           street_2: street2,
-              city: city,
+              city: city.downcase,
              state: state,
                zip: zip)
 

--- a/app/graphql/mutations/create_venue.rb
+++ b/app/graphql/mutations/create_venue.rb
@@ -37,7 +37,7 @@ module Mutations
         venue.addresses.create(
           street_1: street1,
           street_2: street2,
-              city: city,
+              city: city.downcase,
              state: state,
                zip: zip)
         return venue

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -43,7 +43,7 @@ module Types
 
     def all_venues(city: nil, id: nil)
       if city
-        Venue.joins(:addresses).where(addresses: {city: city})
+        Venue.joins(:addresses).where(addresses: {city: city.downcase})
       elsif id
         Venue.where(id: id)
       else

--- a/spec/mutations/create_user_spec.rb
+++ b/spec/mutations/create_user_spec.rb
@@ -20,7 +20,7 @@ class Mutations::CreateUserTest < ActiveSupport::TestCase
       assert user.persisted?
       assert_equal user.username, 'Duce'
       assert_equal user.password, 'password'
-      assert_equal user.addresses[0].city, 'Denver'
+      assert_equal user.addresses[0].city, 'denver'
     end
   end
 end

--- a/spec/mutations/create_venue_spec.rb
+++ b/spec/mutations/create_venue_spec.rb
@@ -22,7 +22,7 @@ class Mutations::CreateUserTest < ActiveSupport::TestCase
 
       assert venue.persisted?
       assert_equal venue.name, 'Venue One'
-      assert_equal venue.addresses[0].city, 'Denver'
+      assert_equal venue.addresses[0].city, 'denver'
     end
 
     it 'throws error when current user is not superuser' do


### PR DESCRIPTION
This addresses a front-end request that city be fully searchable regardless of whether user correctly capitalizes city name or not. Downcases city for all address creation and downcases query.