### PR TITLE
Changes sign in argument name for clarity

### DIFF
--- a/app/graphql/mutations/sign_in.rb
+++ b/app/graphql/mutations/sign_in.rb
@@ -1,16 +1,16 @@
 module Mutations
   class SignIn < Mutations::BaseMutation
-    argument :username, String, required: false
+    argument :name_or_email, String, required: false
     argument :password, String, required: true
 
     field :token, String, null: true
     field :user, Types::UserType, null: true
 
-    def resolve(username: nil, password: nil)
+    def resolve(name_or_email: nil, password: nil)
 
-      user = User.find_by(email: username)
+      user = User.find_by(email: name_or_email)
       if !user
-        user = User.find_by(username: username)
+        user = User.find_by(username: name_or_email)
       end
 
 
@@ -24,7 +24,7 @@ module Mutations
         sleep prng.rand(1000)/1000
         return GraphQL::ExecutionError.new("Invalid credentials")
       end
-      
+
       token = Base64.encode64(user.username)
       {
         token: token,


### PR DESCRIPTION
This changes the sign in argument from `username` to `name_or_email` to reflect the change made to sign in where either works